### PR TITLE
238 update reference data export

### DIFF
--- a/derrida/books/management/commands/reference_data.py
+++ b/derrida/books/management/commands/reference_data.py
@@ -54,7 +54,9 @@ class Command(BaseCommand):
 
             # list of dictionaries can be output as is for JSON export
             with open('{}.json'.format(base_filename), 'w') as jsonfile:
-                json.dump(refdata, jsonfile, indent=2)
+                # Remove fields that are null
+                json_refdata = [{field: ref[field] for field in ref.keys() if ref[field]} for ref in refdata]
+                json.dump(json_refdata, jsonfile, indent=2)
 
             # generate CSV export
             with open('{}.csv'.format(base_filename), 'w') as csvfile:

--- a/derrida/books/management/commands/reference_data.py
+++ b/derrida/books/management/commands/reference_data.py
@@ -18,7 +18,7 @@ import os.path
 
 from django.core.management.base import BaseCommand
 
-from derrida.books.models import DerridaWork
+from derrida.books.models import DerridaWork, DerridaWorkSection
 
 
 class Command(BaseCommand):
@@ -48,6 +48,7 @@ class Command(BaseCommand):
 
             # aggregate reference data to be exported for use in generating
             # CSV and JSON output
+
             refdata = [self.reference_data(ref)
                        for ref in derrida_work.reference_set.all()]
 
@@ -69,6 +70,7 @@ class Command(BaseCommand):
     def reference_data(self, reference):
         '''Generate a dictionary of data to export for a single
          :class:`~derrida.books.models.Reference` object'''
+
         return OrderedDict([
             ('id', reference.get_uri()),
             ('page', reference.derridawork_page),
@@ -85,7 +87,10 @@ class Command(BaseCommand):
             ('interventions', [
                 intervention.get_uri()
                 for intervention in reference.interventions.all()
-            ])
+            ]),
+            # For convenience, assuming that we're only working with De la grammatologie
+            # ('section', reference.section),
+            # ('chapter', reference.chapter),
         ])
 
     def flatten_dict(self, data):

--- a/derrida/books/management/commands/reference_data.py
+++ b/derrida/books/management/commands/reference_data.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
     #: fields for CSV output
     csv_fields = [
         'id', 'page', 'page location', 'type', 'book title', 'book id',
-        'book page', 'book type', 'anchor text', 'interventions'
+        'book page', 'book type', 'anchor text', 'interventions', 'section'
     ]
 
     def add_arguments(self, parser):
@@ -89,7 +89,7 @@ class Command(BaseCommand):
                 for intervention in reference.interventions.all()
             ]),
             # For convenience, assuming that we're only working with De la grammatologie
-            # ('section', reference.section),
+            ('section', reference.get_section()),
             # ('chapter', reference.chapter),
         ])
 

--- a/derrida/books/management/commands/reference_data.py
+++ b/derrida/books/management/commands/reference_data.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
     #: fields for CSV output
     csv_fields = [
         'id', 'page', 'page location', 'type', 'book title', 'book id',
-        'book page', 'book type', 'anchor text', 'interventions', 'section'
+        'book page', 'book type', 'anchor text', 'interventions', 'section', 'chapter',
     ]
 
     def add_arguments(self, parser):
@@ -90,7 +90,7 @@ class Command(BaseCommand):
             ]),
             # For convenience, assuming that we're only working with De la grammatologie
             ('section', reference.get_section()),
-            # ('chapter', reference.chapter),
+            ('chapter', reference.get_chapter()),
         ])
 
     def flatten_dict(self, data):

--- a/derrida/books/models.py
+++ b/derrida/books/models.py
@@ -851,10 +851,9 @@ class Reference(models.Model):
     def get_chapter(self):
         # For convenience, assuming that we're only working with De la grammatologie
         # Not making a property since that seems to mess with solr indexing
+        # Some references have a page number before the first section (?)
 
-        assert False
         for section in DerridaWorkSection.objects.all():
             if section.start_page and section.end_page:
                 if section.start_page <= self.derridawork_page <= section.end_page:
                     return section.name
-                    

--- a/derrida/books/models.py
+++ b/derrida/books/models.py
@@ -848,10 +848,13 @@ class Reference(models.Model):
         PART_2_CUTOFF = 140
         return 'Part 1' if self.derridawork_page <= PART_2_CUTOFF else 'Part 2'
 
-    # @property
-    # def chapter(self):
-    #     # For convenience, assuming that we're only working with De la grammatologie
-    #     for section in DerridaWorkSection.objects.all():
-    #         if section.start_page and section.end_page:
-    #             if section.start_page <= self.derridawork_page <= section.end_page:
-    #                 return section.name
+    def get_chapter(self):
+        # For convenience, assuming that we're only working with De la grammatologie
+        # Not making a property since that seems to mess with solr indexing
+
+        assert False
+        for section in DerridaWorkSection.objects.all():
+            if section.start_page and section.end_page:
+                if section.start_page <= self.derridawork_page <= section.end_page:
+                    return section.name
+                    

--- a/derrida/books/models.py
+++ b/derrida/books/models.py
@@ -841,7 +841,7 @@ class Reference(models.Model):
         return json.dumps(list(ids))
 
     def get_section(self):
-        '''Get the section name for a reference'''
+        '''Get the section name for a reference in grammatologie'''
         # Hard coding because of the way DerridaWorkSection models are set up
         # For convenience, assuming that we're only working with De la grammatologie
         # Not making a property since that seems to mess with solr indexing
@@ -849,11 +849,14 @@ class Reference(models.Model):
         return 'Part 1' if self.derridawork_page <= PART_2_CUTOFF else 'Part 2'
 
     def get_chapter(self):
+        '''Get the chapter name for a reference in grammatologie'''
         # For convenience, assuming that we're only working with De la grammatologie
         # Not making a property since that seems to mess with solr indexing
         # Some references have a page number before the first section (?)
 
         for section in DerridaWorkSection.objects.all():
+            # Chapters have start and end pages, otherwise they're "Part 1" or "Part 2"
+            #  and handled by the get_section method
             if section.start_page and section.end_page:
                 if section.start_page <= self.derridawork_page <= section.end_page:
                     return section.name

--- a/derrida/books/models.py
+++ b/derrida/books/models.py
@@ -839,3 +839,19 @@ class Reference(models.Model):
         ids = with_digital_eds.values_list('id', flat=True).order_by('id')
         # Return serialized JSON
         return json.dumps(list(ids))
+
+    def get_section(self):
+        '''Get the section name for a reference'''
+        # Hard coding because of the way DerridaWorkSection models are set up
+        # For convenience, assuming that we're only working with De la grammatologie
+        # Not making a property since that seems to mess with solr indexing
+        PART_2_CUTOFF = 140
+        return 'Part 1' if self.derridawork_page <= PART_2_CUTOFF else 'Part 2'
+
+    # @property
+    # def chapter(self):
+    #     # For convenience, assuming that we're only working with De la grammatologie
+    #     for section in DerridaWorkSection.objects.all():
+    #         if section.start_page and section.end_page:
+    #             if section.start_page <= self.derridawork_page <= section.end_page:
+    #                 return section.name

--- a/derrida/books/tests/test_commands.py
+++ b/derrida/books/tests/test_commands.py
@@ -154,6 +154,7 @@ class TestReferenceData(TestCase):
         assert refdata['book']['page'] == ref.book_page
         assert refdata['type'] == str(ref.reference_type)
         assert refdata['anchor text'] == ref.anchor_text
+        assert refdata['section'] == ref.get_section()
         assert not refdata['interventions']
 
         # reference *with* corresponding intervention

--- a/derrida/books/tests/test_commands.py
+++ b/derrida/books/tests/test_commands.py
@@ -155,6 +155,7 @@ class TestReferenceData(TestCase):
         assert refdata['type'] == str(ref.reference_type)
         assert refdata['anchor text'] == ref.anchor_text
         assert refdata['section'] == ref.get_section()
+        assert refdata['chapter'] == ref.get_chapter()
         assert not refdata['interventions']
 
         # reference *with* corresponding intervention

--- a/derrida/books/tests/test_models.py
+++ b/derrida/books/tests/test_models.py
@@ -225,7 +225,33 @@ class TestReference(TestCase):
             book_page='10s',
             reference_type=self.quotation
         )
-        
+
+        # Create sections to search through
+        DerridaWorkSection.objects.create(
+            name='Part 1',
+            order=1,
+            derridawork=self.dg,
+            start_page=None,
+            end_page=None
+        )
+
+        DerridaWorkSection.objects.create(
+            name='Chapter 1',
+            order=2,
+            derridawork=self.dg,
+            start_page=1,
+            end_page=107
+        )
+
+        DerridaWorkSection.objects.create(
+            name='Chapter 3',
+            order=2,
+            derridawork=self.dg,
+            start_page=108,
+            end_page=120
+        )
+
+
         assert ref.get_chapter() == 'Chapter 3'
 
 

--- a/derrida/books/tests/test_models.py
+++ b/derrida/books/tests/test_models.py
@@ -216,16 +216,17 @@ class TestReference(TestCase):
         )
         assert ref.get_section() == 'Part 1'
 
-    # def test_chapter(self):
-    #     ref = Reference.objects.create(
-    #         instance=self.la_vie,
-    #         derridawork=self.dg,
-    #         derridawork_page='110',
-    #         derridawork_pageloc='a',
-    #         book_page='10s',
-    #         reference_type=self.quotation
-    #     )
-    #     assert ref.chapter == 'Chapter 3'
+    def test_chapter(self):
+        ref = Reference.objects.create(
+            instance=self.la_vie,
+            derridawork=self.dg,
+            derridawork_page=110,
+            derridawork_pageloc='a',
+            book_page='10s',
+            reference_type=self.quotation
+        )
+        
+        assert ref.get_chapter() == 'Chapter 3'
 
 
 class TestReferenceQuerySet(TestCase):

--- a/derrida/books/tests/test_models.py
+++ b/derrida/books/tests/test_models.py
@@ -251,7 +251,6 @@ class TestReference(TestCase):
             end_page=120
         )
 
-
         assert ref.get_chapter() == 'Chapter 3'
 
 

--- a/derrida/books/tests/test_models.py
+++ b/derrida/books/tests/test_models.py
@@ -204,6 +204,28 @@ class TestReference(TestCase):
         ref.instance = vie_part
         # book should return the collected work
         assert ref.book == self.la_vie
+    
+    def test_get_section(self):
+        ref = Reference.objects.create(
+            instance=self.la_vie,
+            derridawork=self.dg,
+            derridawork_page=110,
+            derridawork_pageloc='a',
+            book_page='10s',
+            reference_type=self.quotation
+        )
+        assert ref.get_section() == 'Part 1'
+
+    # def test_chapter(self):
+    #     ref = Reference.objects.create(
+    #         instance=self.la_vie,
+    #         derridawork=self.dg,
+    #         derridawork_page='110',
+    #         derridawork_pageloc='a',
+    #         book_page='10s',
+    #         reference_type=self.quotation
+    #     )
+    #     assert ref.chapter == 'Chapter 3'
 
 
 class TestReferenceQuerySet(TestCase):


### PR DESCRIPTION
* The original code was written to compare multiple DerridaWorks, but I everythingit assuming that De la Grammatologie is the only work we're using.
* I hard-coded `get_section()` because "Part 1" and "Part 2" doesn't have page number information (?!)
* There are 4 references without chapter information because they occur before the first chapter (?)

New export is attached:
[reference_data.zip](https://github.com/Princeton-CDH/derrida-django/files/6938948/reference_data.zip)


