### PR TITLE
Revise proxy iiif info.json handling for more cases

### DIFF
--- a/derrida/books/views.py
+++ b/derrida/books/views.py
@@ -711,7 +711,7 @@ class ProxyView(View):
                 local_response[header] = value
 
         # special case, for deep zoom json info response
-        if kwargs['mode'] == 'info' or (kwargs['mode'] == 'iiif' and kwargs['url'] in ['/', '/info.json']):
+        if kwargs['mode'] == 'info' or (kwargs['mode'] == 'iiif' and kwargs['url'] in ['/', '/info.json', '']):
             data = remote_response.json(object_pairs_hook=OrderedDict)
             # need to adjust the id to be relative to current url
             # patch in our proxy iiif interface at this url,

--- a/derrida/books/views.py
+++ b/derrida/books/views.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+from collections import OrderedDict
 
 from dal import autocomplete
 from django.contrib import messages
@@ -709,12 +710,13 @@ class ProxyView(View):
                 # need to be made relative to current url
                 local_response[header] = value
 
-        # special case, for deep zoom (hack)
-        if kwargs['mode'] == 'info':
-            data = remote_response.json()
+        # special case, for deep zoom json info response
+        if kwargs['mode'] == 'info' or (kwargs['mode'] == 'iiif' and kwargs['url'] in ['/', '/info.json']):
+            data = remote_response.json(object_pairs_hook=OrderedDict)
             # need to adjust the id to be relative to current url
-            # this is a hack, patching in a proxy iiif interface at this url
-            data['@id'] = absolutize_url(request.path.replace('/info/', '/iiif'),
+            # patch in our proxy iiif interface at this url,
+            # rather than exposing the true (restricted) endpoint in the json
+            data['@id'] = absolutize_url(request.path.replace('/info/', '/iiif').replace('info.json', ''),
                 request)
 
             local_response.content = json.dumps(data)


### PR DESCRIPTION
It turns out I already had code for this, it just wasn't being applied in all the cases where it was needed.

While I was at it, I added an `OrderedDict` for the response json so that we preserve the original order of the output when we modify the id.