### PR TITLE
insertion data export revisions

### DIFF
--- a/DEPLOYNOTES.rst
+++ b/DEPLOYNOTES.rst
@@ -3,6 +3,13 @@
 Deploy and Upgrade notes
 ========================
 
+1.3
+---
+
+* Some mislabeled pages have been corrected in PUL's Figgy; the updated manifests should be re-imported before generating data exports::
+
+  python manage.py import_digitaleds PUL --update
+
 1.2
 ---
 

--- a/derrida/interventions/management/commands/insertion_data.py
+++ b/derrida/interventions/management/commands/insertion_data.py
@@ -57,7 +57,7 @@ class Command(annotation_data.Command):
 
         # canvas label indicates if a canvas is part of an insertion
         insertion_canvases = Canvas.objects.filter(label__contains='Insertion') \
-            .order_by('manifest__instance__pk', 'label')
+            .order_by('manifest__instance__pk', 'order')
 
         insertion_images = defaultdict(list)
         for canvas in insertion_canvases:

--- a/derrida/interventions/management/commands/insertion_data.py
+++ b/derrida/interventions/management/commands/insertion_data.py
@@ -56,7 +56,10 @@ class Command(annotation_data.Command):
         # CSV and JSON output
 
         # canvas label indicates if a canvas is part of an insertion
+        # NOTE: there are insertions in Derrida's copy of dlG, but they
+        # are out of scope for this data exports
         insertion_canvases = Canvas.objects.filter(label__contains='Insertion') \
+            .exclude(manifest__instance__slug='derrida-de-la-grammatologie-1967') \
             .order_by('manifest__instance__pk', 'order')
 
         insertion_images = defaultdict(list)

--- a/derrida/interventions/management/commands/insertion_data.py
+++ b/derrida/interventions/management/commands/insertion_data.py
@@ -40,7 +40,7 @@ class Command(annotation_data.Command):
     #: fields for CSV output
     csv_fields = [
         # match annotation fields where possible (but not a lot of overlap)
-        'id',
+        'id', 'label',
         'book_id', 'book_title', 'book_type', 'page',
         'num_images', 'image_labels', 'image_iiif'
     ]
@@ -115,7 +115,8 @@ class Command(annotation_data.Command):
         page = RE_INSERTION_LABEL.match(first_canvas.label).group('page')
 
         return OrderedDict([
-            ('id', label),   # provisional
+            ('id', '%s/%s' % (first_canvas.manifest.short_id, first_canvas.short_id)),
+            ('label', label),
             ('book', OrderedDict([
                 ('id', book.get_uri()),
                 ('title', book.display_title()),

--- a/derrida/interventions/management/commands/insertion_data.py
+++ b/derrida/interventions/management/commands/insertion_data.py
@@ -56,7 +56,8 @@ class Command(annotation_data.Command):
         # CSV and JSON output
 
         # canvas label indicates if a canvas is part of an insertion
-        insertion_canvases = Canvas.objects.filter(label__contains='Insertion')
+        insertion_canvases = Canvas.objects.filter(label__contains='Insertion') \
+            .order_by('manifest__instance__pk', 'label')
 
         insertion_images = defaultdict(list)
         for canvas in insertion_canvases:

--- a/derrida/interventions/tests.py
+++ b/derrida/interventions/tests.py
@@ -1050,7 +1050,8 @@ class TestInsertionData(TestCase):
                 # check the data generated
                 result = jsondata[0]
                 # label includes book, author, and insertion label
-                assert result['id'] == 'Montaigne. Essais. pp. 244-245 Insertion A'
+                assert result['id'] == '%s/%s' % (insertions[0].manifest.short_id, insertions[0].short_id)
+                assert result['label'] == 'Montaigne. Essais. pp. 244-245 Insertion A'
                 # page range pulled from insertion image label
                 assert result['page'] == 'pp. 244-245'
                 assert result['book']['type'] == 'Book'


### PR DESCRIPTION
- added a deploy note about importing updated manifests to get corrected page labels from figgy
- order canvases by item and label so that insertions within a work will group together

questions:
- All book type values are book because only books can have insertions. Drop the field and note in the dataset readme?
- the `id` field doesn't really look like an id to me; what if we call it label? (do we need an id?)